### PR TITLE
Remove create branch, add and commit

### DIFF
--- a/.github/workflows/generate-blueprint2.yaml
+++ b/.github/workflows/generate-blueprint2.yaml
@@ -45,16 +45,6 @@ jobs:
           git config user.name "GitHub Actions Bot"
           git config user.email "<>"
 
-      # Updated section with branch creation and PR creation step
-      - name: Create a new branch for updates
-        run: |
-          git checkout -b blueprint-updates
-
-      - name: Commit updates to the new branch
-        run: |
-          git add $(pwd)/aws-rds-postgresql/generic/
-          git commit -m "update blueprints for RDS module"
-
       - name: Create a pull request
         uses: peter-evans/create-pull-request@v6
         with:


### PR DESCRIPTION
According to the documentation at https://github.com/peter-evans/create-pull-request this plugin will create the branch, the adds and the commit for you. 

According to this bug https://github.com/peter-evans/create-pull-request/issues/1716 we are in the same situation because we have created the branch ourself.