### PR TITLE
Fix breaking changes in Terragrunt

### DIFF
--- a/tools/scaffolding/scripts/entrypoint.sh
+++ b/tools/scaffolding/scripts/entrypoint.sh
@@ -81,7 +81,7 @@ if [ -d $tg_module_template_folder ]; then
 	cp $tg_root_template $tg_output_folders/root.hcl
 	cp $tg_env_template $tg_output_folders_test/env.hcl
 
-	terragrunt hclfmt --terragrunt-working-dir $tg_output_folders
+	terragrunt hclfmt --working-dir $tg_output_folders
 else
 	echo "No terragrunt module template provided"
 fi


### PR DESCRIPTION
This pull request makes a minor update to the Terragrunt formatting command in the `tools/scaffolding/scripts/entrypoint.sh` script. The change ensures compatibility with the latest Terragrunt CLI option naming.

* Changed the Terragrunt formatting command from `--terragrunt-working-dir` to `--working-dir` for improved compatibility.